### PR TITLE
Remove anyhow and use custom error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ serde_derive = "1.0.102"
 walkdir = "2.2.9"
 either = "1.5.3"
 async-std = { version = "1.0.1", features = ["unstable"] }
-anyhow = "1.0.19"
 thiserror = "1.0.5"
 futures = "0.3.1"
 

--- a/src/content/rm.rs
+++ b/src/content/rm.rs
@@ -1,18 +1,20 @@
 use std::fs;
 use std::path::Path;
 
-use anyhow::Result;
 use async_std::fs as afs;
 use ssri::Integrity;
 
 use crate::content::path;
+use crate::errors::{Internal, Result};
 
 pub fn rm(cache: &Path, sri: &Integrity) -> Result<()> {
-    fs::remove_file(path::content_path(&cache, &sri))?;
+    fs::remove_file(path::content_path(&cache, &sri)).to_internal()?;
     Ok(())
 }
 
 pub async fn rm_async(cache: &Path, sri: &Integrity) -> Result<()> {
-    afs::remove_file(path::content_path(&cache, &sri)).await?;
+    afs::remove_file(path::content_path(&cache, &sri))
+        .await
+        .to_internal()?;
     Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,34 @@
 use std::path::PathBuf;
 
-use ssri::Integrity;
 use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("{source}\n\n  {}", context.join("\n  "))]
+pub struct InternalError {
+    source: Box<dyn std::error::Error + Send + Sync>,
+    context: Vec<String>,
+}
+
+pub trait Internal<T> {
+    fn to_internal(self) -> InternalResult<T>;
+    fn with_context<F: FnOnce() -> String>(self, f: F) -> InternalResult<T>;
+}
+
+impl<T, E: 'static + std::error::Error + Send + Sync> Internal<T> for std::result::Result<T, E> {
+    fn to_internal(self) -> InternalResult<T> {
+        self.map_err(|e| InternalError {
+            source: Box::new(e),
+            context: Vec::new(),
+        })
+    }
+
+    fn with_context<F: FnOnce() -> String>(self, f: F) -> InternalResult<T> {
+        self.map_err(|e| InternalError {
+            source: Box::new(e),
+            context: vec![f()],
+        })
+    }
+}
 
 /// Error type returned by all API calls.
 #[derive(Error, Debug)]
@@ -10,10 +37,29 @@ pub enum Error {
     /// lookup.
     #[error("Entry not found for key {1:?} in cache {0:?}")]
     EntryNotFound(PathBuf, String),
-    /// Returned when an integrity check has failed.
-    #[error("Integrity check failed.\n\tWanted: {0}\n\tActual: {1}")]
-    IntegrityError(Integrity, Integrity),
+
     /// Returned when a size check has failed.
     #[error("Size check failed.\n\tWanted: {0}\n\tActual: {1}")]
     SizeError(usize, usize),
+
+    /// Returned when an integrity check has failed.
+    #[error(transparent)]
+    IntegrityError {
+        #[from]
+        /// The underlying error
+        source: ssri::Error,
+    },
+
+    /// Returned if an internal (e.g. io) operation has failed.
+    #[error(transparent)]
+    InternalError {
+        #[from]
+        /// The underlying error
+        source: InternalError,
+    },
 }
+
+/// The result type returned by calls to this library
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub type InternalResult<T> = std::result::Result<T, InternalError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,9 @@
 //!
 //! ```no_run
 //! use async_attributes;
-//! use anyhow::Result;
 //!
 //! #[async_attributes::main]
-//! async fn main() -> Result<()> {
+//! async fn main() -> cacache::Result<()> {
 //!   // Data goes in...
 //!   cacache::write("./my-cache", "key", b"hello").await?;
 //!
@@ -60,10 +59,9 @@
 //!
 //! ```no_run
 //! use async_attributes;
-//! use anyhow::Result;
 //!
 //! #[async_attributes::main]
-//! async fn main() -> Result<()> {
+//! async fn main() -> cacache::Result<()> {
 //!   // Data goes in...
 //!   let sri = cacache::write("./my-cache", "key", b"hello").await?;
 //!
@@ -81,15 +79,14 @@
 //! an API reminiscent of `std::fs::OpenOptions`:
 //!
 //! ```no_run
-//! use anyhow::Result;
 //! use async_attributes;
 //! use async_std::prelude::*;
 //!
 //! #[async_attributes::main]
-//! async fn main() -> Result<()> {
+//! async fn main() -> cacache::Result<()> {
 //!   let mut fd = cacache::Writer::create("./my-cache", "key").await?;
 //!   for _ in 0..10 {
-//!     fd.write_all(b"very large data").await?;
+//!     fd.write_all(b"very large data").await.expect("Failed to write to cache");
 //!   }
 //!   // Data is only committed to the cache after you do `fd.commit()`!
 //!   let sri = fd.commit().await?;
@@ -97,7 +94,7 @@
 //!
 //!   let mut fd = cacache::Reader::open("./my-cache", "key").await?;
 //!   let mut buf = String::new();
-//!   fd.read_to_string(&mut buf).await?;
+//!   fd.read_to_string(&mut buf).await.expect("Failed to read to string");
 //!
 //!   // Make sure to call `.check()` when you're done! It makes sure that what
 //!   // you just read is actually valid. `cacache` always verifies the data
@@ -117,8 +114,7 @@
 //! application, you probably want to use these instead.
 //!
 //! ```no_run
-//! use anyhow::Result;
-//! fn main() -> Result<()> {
+//! fn main() -> cacache::Result<()> {
 //!   cacache::write_sync("./my-cache", "key", b"my-data").unwrap();
 //!   let data = cacache::read_sync("./my-cache", "key").unwrap();
 //!   assert_eq!(data, b"my-data");
@@ -139,7 +135,7 @@ mod ls;
 mod put;
 mod rm;
 
-pub use errors::Error;
+pub use errors::{Error, Result};
 pub use index::Metadata;
 
 pub use get::*;


### PR DESCRIPTION
So, I found some time to think about error handling :)

I am not sure if I am completely happy with it. I think I accidentally changed some things which didn't really need changing, as it was also kind of an exploratory process. We now have 2 different classes of errors (represented in one enum). Internal ones which mainly serve debugging purposes if something inside of the library broke (e.g. underlying IO is not working or some serializing didn't work). And external ones which the user might want to handle (Size/Integrity mismatch and NotFound, mostly). Internal errors can be extended using `with_context()`, to allow for easier debugging.

Because I found the implicit conversions of errors to our internal error type to be a little bit to much magic, I decided to make all of them explicit. Not sure if this is a good choice.

This PR is just a suggestion of how this might be handled for now. If you agree on the basic direction I might add some more polish and clean the whole thing up a little bit more. There are some additional comments by me on the single commit.

**Edit:**
Ok, now I know how github formats commit comments on a PR...