### PR TITLE
fix(list_sync): make sure the public interface allows using the Item type

### DIFF
--- a/src/ls.rs
+++ b/src/ls.rs
@@ -1,9 +1,29 @@
 //! Functions for iterating over the cache.
+use anyhow::Result;
 use std::path::Path;
 
 use crate::index;
 
 /// Returns a synchronous iterator that lists all cache index entries.
-pub fn list_sync<P: AsRef<Path>>(cache: P) -> impl Iterator {
+pub fn list_sync<P: AsRef<Path>>(cache: P) -> impl Iterator<Item = Result<index::Metadata>> {
     index::ls(cache.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile;
+
+    #[test]
+    fn test_list_sync() {
+        // check that the public interface to list elements can actually use the
+        // Iterator::Item
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_owned();
+
+        assert!(list_sync(dir)
+            .map(|x| Ok(x?.key))
+            .collect::<Result<Vec<_>>>()
+            .is_err())
+    }
 }


### PR DESCRIPTION
Before this change the public interface wouldn't allow downstream users
to use the actual items since it wasn't communicated on the function
signature.

Previously a user would run into erorrs like this:
> no field `key` on type `<impl std::iter::Iterator as std::iter::Iterator>::Item`