### PR TITLE
Update ssri dependency to 6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ssri = "5.0.0"
+ssri = "6.0.0"
 hex = "0.4.0"
 tempfile = "3.1.0"
 sha-1 = "0.8.1"

--- a/src/content/write.rs
+++ b/src/content/write.rs
@@ -216,7 +216,7 @@ impl AsyncWriter {
 
 impl AsyncWrite for AsyncWriter {
     fn poll_write(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
@@ -273,7 +273,7 @@ impl AsyncWrite for AsyncWriter {
         }
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         let state = &mut *self.0.lock().unwrap();
 
         loop {
@@ -313,7 +313,7 @@ impl AsyncWrite for AsyncWriter {
         }
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         let state = &mut *self.0.lock().unwrap();
 
         loop {


### PR DESCRIPTION
Without this update, cacache cannot be used with the most recent version of ssri.

Signed-off-by: David Calavera <david.calavera@gmail.com>