### PR TITLE
Add support for choosing between async-std and Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/zkat/cacache-rs"
 homepage = "https://github.com/zkat/cacache-rs"
 readme = "README.md"
-categories = [
-    "caching",
-    "filesystem"
-]
+categories = ["caching", "filesystem"]
 
 [dependencies]
 ssri = "7.0.0"
@@ -25,15 +22,28 @@ serde = "1.0.130"
 serde_derive = "1.0.130"
 walkdir = "2.3.2"
 either = "1.6.1"
-async-std = { version = "1.10.0", features = ["unstable"] }
+async-std = { version = "1.10.0", features = ["unstable"], optional = true }
+tokio = { version = "1.12.0", features = [
+    "fs",
+    "io-util",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+], optional = true }
+tokio-stream = { version = "0.1.7", features = ["io-util"], optional = true }
 thiserror = "1.0.29"
 futures = "0.3.17"
 memmap = "0.7.0"
 
 [dev-dependencies]
+async-std = { version = "1.10.0", features = ["unstable"] }
 async-attributes = "1.1.2"
 criterion = "0.3.5"
 
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[features]
+default = ["async-std"]
+tokio-runtime = ["tokio", "tokio-stream"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Minimum supported Rust version is `1.43.0`.
 
 ## Features
 
-- First-class async support, using [`async-std`](https://crates.io/crates/async-std) as its runtime. Sync APIs are available but secondary
+- First-class async support, using either [`async-std`](https://crates.io/crates/async-std) or [`tokio`](https://crates.io/crates/tokio) as its runtime. Sync APIs are available but secondary
 - `std::fs`-style API
 - Extraction by key or by content address (shasum, etc)
 - [Subresource Integrity](#integrity) web standard support

--- a/src/async_lib.rs
+++ b/src/async_lib.rs
@@ -1,0 +1,126 @@
+#[cfg(feature = "async-std")]
+pub use async_std::fs::File;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::File;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncRead;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncRead;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncReadExt;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncReadExt;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncBufReadExt;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncBufReadExt;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncWrite;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncWrite;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncWriteExt;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncWriteExt;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::read;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::read;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::copy;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::copy;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::metadata;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::metadata;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::remove_file;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::remove_file;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::create_dir_all;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::create_dir_all;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::remove_dir_all;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::remove_dir_all;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::DirBuilder;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::DirBuilder;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::OpenOptions;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::OpenOptions;
+
+#[cfg(feature = "async-std")]
+pub use async_std::io::BufReader;
+#[cfg(feature = "tokio")]
+pub use tokio::io::BufReader;
+
+#[cfg(feature = "async-std")]
+#[inline]
+pub fn lines_to_stream<R>(lines: futures::io::Lines<R>) -> futures::io::Lines<R> {
+    lines
+}
+#[cfg(feature = "tokio")]
+#[inline]
+pub fn lines_to_stream<R>(lines: tokio::io::Lines<R>) -> tokio_stream::wrappers::LinesStream<R> {
+    tokio_stream::wrappers::LinesStream::new(lines)
+}
+
+#[cfg(feature = "async-std")]
+pub use async_std::task::spawn_blocking;
+#[cfg(feature = "tokio")]
+pub use tokio::task::spawn_blocking;
+
+#[cfg(all(test, feature = "async-std"))]
+pub use async_std::task::block_on;
+#[cfg(all(test, feature = "tokio"))]
+#[inline]
+pub fn block_on<F, T>(future: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
+}
+
+#[cfg(feature = "async-std")]
+pub use async_std::task::JoinHandle;
+#[cfg(feature = "async-std")]
+#[inline]
+pub async fn unwrap_joinhandle<R>(handle: async_std::task::JoinHandle<R>) -> R {
+    handle.await
+}
+#[cfg(feature = "async-std")]
+#[inline]
+pub fn unwrap_joinhandle_value<T>(value: T) -> T {
+    value
+}
+#[cfg(feature = "tokio")]
+pub use tokio::task::JoinHandle;
+#[cfg(feature = "tokio")]
+#[inline]
+pub async fn unwrap_joinhandle<R>(handle: tokio::task::JoinHandle<R>) -> R {
+    handle.await.unwrap()
+}
+#[cfg(feature = "tokio")]
+#[inline]
+pub fn unwrap_joinhandle_value<T>(value: Result<T, tokio::task::JoinError>) -> T {
+    value.unwrap()
+}

--- a/src/content/rm.rs
+++ b/src/content/rm.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::Path;
 
-use async_std::fs as afs;
 use ssri::Integrity;
 
 use crate::content::path;
@@ -13,7 +12,7 @@ pub fn rm(cache: &Path, sri: &Integrity) -> Result<()> {
 }
 
 pub async fn rm_async(cache: &Path, sri: &Integrity) -> Result<()> {
-    afs::remove_file(path::content_path(cache, sri))
+    crate::async_lib::remove_file(path::content_path(cache, sri))
         .await
         .to_internal()?;
     Ok(())

--- a/src/content/write.rs
+++ b/src/content/write.rs
@@ -3,11 +3,9 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Mutex;
+use std::task::{Context, Poll};
 
-use async_std::fs as afs;
-use async_std::future::Future;
-use async_std::task::{self, Context, JoinHandle, Poll};
-use futures::io::AsyncWrite;
+use crate::async_lib::{AsyncWrite, JoinHandle};
 use futures::prelude::*;
 use memmap::MmapMut;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
@@ -115,14 +113,16 @@ impl AsyncWriter {
         let cache_path = cache.to_path_buf();
         let mut tmp_path = cache_path.clone();
         tmp_path.push("tmp");
-        afs::DirBuilder::new()
+        crate::async_lib::DirBuilder::new()
             .recursive(true)
             .create(&tmp_path)
             .await
             .to_internal()?;
-        let tmpfile = task::spawn_blocking(|| NamedTempFile::new_in(tmp_path))
-            .await
-            .to_internal()?;
+        let tmpfile = crate::async_lib::unwrap_joinhandle(crate::async_lib::spawn_blocking(|| {
+            NamedTempFile::new_in(tmp_path)
+        }))
+        .await
+        .to_internal()?;
         let mmap = if let Some(size) = size {
             if size <= MAX_MMAP_SIZE {
                 unsafe { MmapMut::map_mut(tmpfile.as_file()).ok() }
@@ -160,7 +160,7 @@ impl AsyncWriter {
                             let cpath = path::content_path(&inner.cache, &sri);
 
                             // Start the operation asynchronously.
-                            *state = State::Busy(task::spawn_blocking(|| {
+                            *state = State::Busy(crate::async_lib::spawn_blocking(|| {
                                 let res = std::fs::DirBuilder::new()
                                     .recursive(true)
                                     // Safe unwrap. cpath always has multiple segments
@@ -202,7 +202,11 @@ impl AsyncWriter {
                         }
                     },
                     // Poll the asynchronous operation the file is currently blocked on.
-                    State::Busy(task) => *state = futures::ready!(Pin::new(task).poll(cx)),
+                    State::Busy(task) => {
+                        *state = crate::async_lib::unwrap_joinhandle_value(futures::ready!(
+                            Pin::new(task).poll(cx)
+                        ))
+                    }
                 }
             }
         })
@@ -253,7 +257,7 @@ impl AsyncWrite for AsyncWriter {
                         inner.buf[..buf.len()].copy_from_slice(buf);
 
                         // Start the operation asynchronously.
-                        *state = State::Busy(task::spawn_blocking(|| {
+                        *state = State::Busy(crate::async_lib::spawn_blocking(|| {
                             inner.builder.input(&inner.buf);
                             if let Some(mmap) = &mut inner.mmap {
                                 mmap.copy_from_slice(&inner.buf);
@@ -268,7 +272,12 @@ impl AsyncWrite for AsyncWriter {
                     }
                 }
                 // Poll the asynchronous operation the file is currently blocked on.
-                State::Busy(task) => *state = futures::ready!(Pin::new(task).poll(cx)),
+                State::Busy(task) => {
+                    *state = crate::async_lib::unwrap_joinhandle_value(futures::ready!(Pin::new(
+                        task
+                    )
+                    .poll(cx)))
+                }
             }
         }
     }
@@ -300,7 +309,7 @@ impl AsyncWrite for AsyncWriter {
                         }
 
                         // Start the operation asynchronously.
-                        *state = State::Busy(task::spawn_blocking(|| {
+                        *state = State::Busy(crate::async_lib::spawn_blocking(|| {
                             let res = inner.tmpfile.flush();
                             inner.last_op = Some(Operation::Flush(res));
                             State::Idle(Some(inner))
@@ -308,12 +317,33 @@ impl AsyncWrite for AsyncWriter {
                     }
                 }
                 // Poll the asynchronous operation the file is currently blocked on.
-                State::Busy(task) => *state = futures::ready!(Pin::new(task).poll(cx)),
+                State::Busy(task) => {
+                    *state = crate::async_lib::unwrap_joinhandle_value(futures::ready!(Pin::new(
+                        task
+                    )
+                    .poll(cx)))
+                }
             }
         }
     }
 
+    #[cfg(feature = "async-std")]
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.poll_close_impl(cx)
+    }
+
+    #[cfg(feature = "tokio")]
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.poll_close_impl(cx)
+    }
+}
+
+impl AsyncWriter {
+    #[inline]
+    fn poll_close_impl(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
         let state = &mut *self.0.lock().unwrap();
 
         loop {
@@ -327,13 +357,18 @@ impl AsyncWrite for AsyncWriter {
                     };
 
                     // Start the operation asynchronously.
-                    *state = State::Busy(task::spawn_blocking(|| {
+                    *state = State::Busy(crate::async_lib::spawn_blocking(|| {
                         drop(inner);
                         State::Idle(None)
                     }));
                 }
                 // Poll the asynchronous operation the file is currently blocked on.
-                State::Busy(task) => *state = futures::ready!(Pin::new(task).poll(cx)),
+                State::Busy(task) => {
+                    *state = crate::async_lib::unwrap_joinhandle_value(futures::ready!(Pin::new(
+                        task
+                    )
+                    .poll(cx)))
+                }
             }
         }
     }
@@ -346,7 +381,7 @@ fn io_error(err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> std::io
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_std::task;
+    use crate::async_lib::AsyncWriteExt;
     use tempfile;
     #[test]
     fn basic_write() {
@@ -366,7 +401,7 @@ mod tests {
     fn basic_async_write() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().to_owned();
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             let mut writer = AsyncWriter::new(&dir, Algorithm::Sha256, None)
                 .await
                 .unwrap();

--- a/src/index.rs
+++ b/src/index.rs
@@ -5,11 +5,8 @@ use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use async_std::fs as afs;
-use async_std::io::BufReader;
 use digest::Digest;
 use either::{Left, Right};
-use futures::io::{AsyncBufReadExt, AsyncWriteExt};
 use futures::stream::StreamExt;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
@@ -18,6 +15,7 @@ use sha2::Sha256;
 use ssri::Integrity;
 use walkdir::WalkDir;
 
+use crate::async_lib::{AsyncBufReadExt, AsyncWriteExt};
 use crate::errors::{Internal, InternalResult, Result};
 use crate::put::WriteOpts;
 
@@ -97,7 +95,7 @@ pub fn insert(cache: &Path, key: &str, opts: WriteOpts) -> Result<Integrity> {
 
 pub async fn insert_async<'a>(cache: &'a Path, key: &'a str, opts: WriteOpts) -> Result<Integrity> {
     let bucket = bucket_path(cache, key);
-    afs::create_dir_all(bucket.parent().unwrap())
+    crate::async_lib::create_dir_all(bucket.parent().unwrap())
         .await
         .with_context(|| {
             format!(
@@ -114,7 +112,7 @@ pub async fn insert_async<'a>(cache: &'a Path, key: &'a str, opts: WriteOpts) ->
     })
     .with_context(|| format!("Failed to serialize entry with key `{}`", key))?;
 
-    let mut buck = async_std::fs::OpenOptions::new()
+    let mut buck = crate::async_lib::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&bucket)
@@ -311,7 +309,7 @@ fn bucket_entries(bucket: &Path) -> InternalResult<Vec<SerializableMetadata>> {
 }
 
 async fn bucket_entries_async(bucket: &Path) -> InternalResult<Vec<SerializableMetadata>> {
-    let file_result = afs::File::open(bucket).await;
+    let file_result = crate::async_lib::File::open(bucket).await;
     let file;
     if let Err(err) = file_result {
         if err.kind() == ErrorKind::NotFound {
@@ -322,7 +320,8 @@ async fn bucket_entries_async(bucket: &Path) -> InternalResult<Vec<SerializableM
         file = file_result.unwrap();
     }
     let mut vec = Vec::new();
-    let mut lines = BufReader::new(file).lines();
+    let mut lines =
+        crate::async_lib::lines_to_stream(crate::async_lib::BufReader::new(file).lines());
     while let Some(line) = lines.next().await {
         if let Ok(entry) = line {
             let entry_str = match entry.split('\t').collect::<Vec<&str>>()[..] {
@@ -341,7 +340,6 @@ async fn bucket_entries_async(bucket: &Path) -> InternalResult<Vec<SerializableM
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_std::task;
     use serde_json::json;
 
     const MOCK_ENTRY: &str = "\n251d18a2b33264ea8655695fd23c88bd874cdea2c3dc9d8f9b7596717ad30fec\t{\"key\":\"hello\",\"integrity\":\"sha1-deadbeef\",\"time\":1234567,\"size\":0,\"metadata\":null}";
@@ -365,7 +363,7 @@ mod tests {
         let sri: Integrity = "sha1-deadbeef".parse().unwrap();
         let time = 1_234_567;
         let opts = WriteOpts::new().integrity(sri).time(time);
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             insert_async(&dir, "hello", opts).await.unwrap();
         });
         let entry = std::fs::read_to_string(bucket_path(&dir, "hello")).unwrap();
@@ -421,7 +419,7 @@ mod tests {
         let time = 1_234_567;
         let opts = WriteOpts::new().integrity(sri).time(time);
         insert(&dir, "hello", opts).unwrap();
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             delete_async(&dir, "hello").await.unwrap();
         });
         assert_eq!(find(&dir, "hello").unwrap(), None);
@@ -455,10 +453,11 @@ mod tests {
         let sri: Integrity = "sha1-deadbeef".parse().unwrap();
         let time = 1_234_567;
         let opts = WriteOpts::new().integrity(sri.clone()).time(time);
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             insert_async(&dir, "hello", opts).await.unwrap();
         });
-        let entry = task::block_on(async { find_async(&dir, "hello").await.unwrap().unwrap() });
+        let entry =
+            crate::async_lib::block_on(async { find_async(&dir, "hello").await.unwrap().unwrap() });
         assert_eq!(
             entry,
             Metadata {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,16 @@
 //! ```
 #![warn(missing_docs, missing_doc_code_examples)]
 
+#[cfg(not(any(feature = "async-std", feature = "tokio-runtime")))]
+compile_error!("Either feature \"async-std\" or \"tokio-runtime\" must be enabled for this crate.");
+
+#[cfg(all(feature = "async-std", feature = "tokio-runtime"))]
+compile_error!("Only either feature \"async-std\" or \"tokio-runtime\" must be enabled for this crate, not both.");
+
 pub use serde_json::Value;
 pub use ssri::Algorithm;
+
+mod async_lib;
 
 mod content;
 mod errors;

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -2,8 +2,6 @@
 use std::fs;
 use std::path::Path;
 
-use async_std::fs as afs;
-
 use ssri::Integrity;
 
 use crate::content::rm;
@@ -93,7 +91,9 @@ pub async fn remove_hash<P: AsRef<Path>>(cache: P, sri: &Integrity) -> Result<()
 /// ```
 pub async fn clear<P: AsRef<Path>>(cache: P) -> Result<()> {
     for entry in (cache.as_ref().read_dir().to_internal()?).flatten() {
-        afs::remove_dir_all(entry.path()).await.to_internal()?;
+        crate::async_lib::remove_dir_all(entry.path())
+            .await
+            .to_internal()?;
     }
     Ok(())
 }
@@ -182,11 +182,9 @@ pub fn clear_sync<P: AsRef<Path>>(cache: P) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use async_std::task;
-
     #[test]
     fn test_remove() {
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();
@@ -203,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_remove_data() {
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();
@@ -220,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();


### PR DESCRIPTION
Hello! 👋

I wanted to use this library, but all my async code is using Tokio as the runtime, so the fact that this library was using async-std meant that I couldn't use it. However, after investigating a little, I realized that for the two runtimes are nearly drop-in replaceable, so I added a small "compatibility-layer" module (named `async_lib`) to the project, which exports the currently selected runtime's primitives (and occasional shims, where required) so that the actual business logic code remains mostly the same as it did before.

While the code passes regular tests, I have not yet modified the documentation tests/examples, because I'm honestly not sure how to best ensure that the example uses the right runtime without it looking messy in the documentation. So the doctests currently only pass when async-std is selected as the runtime.

As for the benchmarks, dev-dependencies are not allowed to be optional, so I couldn't find a way to make it work for both runtimes, and so I've left the benchmarks only compatible with async-std for now.

I updated the README.md to state that Tokio is now supported, but I didn't specify how to pick the runtime, since I wasn't quite sure where to fit it in. I left async-std as the default runtime, and if a user wants tokio instead, they must do something like
```toml
cacache = { version = "*", default-features = false, features = ["tokio-runtime"] }
```

Let me know if you have any thoughts on what I should do with doctests and/or benchmarks if that is currently an issue for accepting this PR, as well as any other feedback you may have. ☺️