### PR TITLE
Fixes RUSTSEC-2020-0077 by replacing memmap with memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ either = "1.6.1"
 async-std = { version = "1.10.0", features = ["unstable"] }
 thiserror = "1.0.29"
 futures = "0.3.17"
-memmap = "0.7.0"
+memmap2 = "0.5"
 
 [dev-dependencies]
 async-attributes = "1.1.2"

--- a/src/content/write.rs
+++ b/src/content/write.rs
@@ -9,7 +9,7 @@ use async_std::future::Future;
 use async_std::task::{self, Context, JoinHandle, Poll};
 use futures::io::AsyncWrite;
 use futures::prelude::*;
-use memmap::MmapMut;
+use memmap2::MmapMut;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
 use tempfile::NamedTempFile;
 


### PR DESCRIPTION
Fixes [RUSTSEC-2020-0077](https://rustsec.org/advisories/RUSTSEC-2020-0077.html) by replacing memmap with [memmap2](https://docs.rs/memmap2/latest/memmap2/)