### PR TITLE
feature(async): Add tokio as an executor option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,24 +8,23 @@ license = "Apache-2.0"
 repository = "https://github.com/zkat/cacache-rs"
 homepage = "https://github.com/zkat/cacache-rs"
 readme = "README.md"
-categories = [
-    "caching",
-    "filesystem"
-]
+categories = ["caching", "filesystem"]
 
 [dependencies]
-ssri = "7.0.0"
+async-attributes = { version = "1.1.2", optional = true }
+async-std = { version = "1.10.0", features = ["unstable"], optional = true }
+digest = "0.10.6"
+either = "1.6.1"
+futures = "0.3.17"
 hex = "0.4.3"
-tempfile = "3.2.0"
-sha-1 = "0.9.8"
-sha2 = "0.9.8"
-digest = "0.9.0"
-serde_json = "1.0.68"
+memmap2 = "0.5.8"
 serde = "1.0.130"
 serde_derive = "1.0.130"
-walkdir = "2.3.2"
-either = "1.6.1"
-async-std = { version = "1.10.0", features = ["unstable"] }
+serde_json = "1.0.68"
+sha1 = "0.10.5"
+sha2 = "0.10.6"
+ssri = "7.0.0"
+tempfile = "3.2.0"
 thiserror = "1.0.29"
 tokio = { version = "1.12.0", features = [
     "fs",
@@ -35,20 +34,15 @@ tokio = { version = "1.12.0", features = [
     "rt-multi-thread",
 ], optional = true }
 tokio-stream = { version = "0.1.7", features = ["io-util"], optional = true }
-
-[features]
-futures = "0.3.17"
-memmap2 = "0.5"
+walkdir = "2.3.2"
 
 [dev-dependencies]
-async-std = { version = "1.10.0", features = ["unstable"] }
-async-attributes = "1.1.2"
-criterion = "0.3.5"
+criterion = "0.4.0"
 
 [[bench]]
 name = "benchmarks"
 harness = false
 
 [features]
-default = ["async-std"]
+default = ["async-std", "async-attributes"]
 tokio-runtime = ["tokio", "tokio-stream"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,28 @@ walkdir = "2.3.2"
 either = "1.6.1"
 async-std = { version = "1.10.0", features = ["unstable"] }
 thiserror = "1.0.29"
+tokio = { version = "1.12.0", features = [
+    "fs",
+    "io-util",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+], optional = true }
+tokio-stream = { version = "0.1.7", features = ["io-util"], optional = true }
+
+[features]
 futures = "0.3.17"
 memmap2 = "0.5"
 
 [dev-dependencies]
+async-std = { version = "1.10.0", features = ["unstable"] }
 async-attributes = "1.1.2"
 criterion = "0.3.5"
 
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[features]
+default = ["async-std"]
+tokio-runtime = ["tokio", "tokio-stream"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Minimum supported Rust version is `1.43.0`.
 
 ## Features
 
-- First-class async support, using [`async-std`](https://crates.io/crates/async-std) as its runtime. Sync APIs are available but secondary
+- First-class async support, using either [`async-std`](https://crates.io/crates/async-std) or [`tokio`](https://crates.io/crates/tokio) as its runtime. Sync APIs are available but secondary
 - `std::fs`-style API
 - Extraction by key or by content address (shasum, etc)
 - [Subresource Integrity](#integrity) web standard support

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Minimum supported Rust version is `1.43.0`.
 - Cross-platform: Windows and case-(in)sensitive filesystem support
 - Punches nazis
 
+`async-std` is the default async runtime. To use `tokio` instead, turn off default features and enable the `tokio-runtime` feature, like this:
+
+```toml
+[dependencies]
+cacache = { version = "*", default-features = false, features = ["tokio-runtime"] }
+```
+
 ## Contributing
 
 The cacache team enthusiastically welcomes contributions and project participation! There's a bunch of things you can do if you want to contribute! The [Contributor Guide](CONTRIBUTING.md) has all the information you need for everything from reporting bugs to contributing entire new features. Please don't hesitate to jump in if you'd like to, or even ask us questions if something isn't clear.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,44 @@
+# List available just recipes
+@help:
+    just -l
+
+# Run tests on both runtimes with cargo nextest
+@test:
+    echo "----------\nasync-std:\n"
+    cargo nextest run
+    echo "\n----------\ntokio:\n"
+    cargo nextest run --no-default-features --features tokio-runtime
+
+# Run benchmarks with `cargo bench`
+@bench:
+    echo "----------\nasync-std:\n"
+    cargo bench
+    echo "\n----------\ntokio:\n"
+    cargo bench --no-default-features --features tokio-runtime
+
+# Run benchmarks with `cargo criterion`
+@criterion:
+    echo "----------\nasync-std:\n"
+    cargo criterion
+    echo "\n----------\ntokio:\n"
+    cargo criterion --no-default-features --features tokio-runtime
+
+# Generate a changelog with git-cliff
+changelog TAG:
+    git-cliff --prepend CHANGELOG.md -u --tag {{TAG}}
+
+# Prepare a release
+release *args:
+    cargo release --workspace {{args}}
+
+# Install workspace tools
+@install-tools:
+    cargo install cargo-nextest
+    cargo install cargo-release
+    cargo install git-cliff
+    cargo install cargo-criterion
+
+# Lint and automatically fix what we can fix
+@lint:
+    cargo clippy --fix --allow-dirty --allow-staged
+    cargo fmt

--- a/src/async_lib.rs
+++ b/src/async_lib.rs
@@ -1,0 +1,126 @@
+#[cfg(feature = "async-std")]
+pub use async_std::fs::File;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::File;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncRead;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncRead;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncReadExt;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncReadExt;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncBufReadExt;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncBufReadExt;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncWrite;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncWrite;
+
+#[cfg(feature = "async-std")]
+pub use futures::io::AsyncWriteExt;
+#[cfg(feature = "tokio")]
+pub use tokio::io::AsyncWriteExt;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::read;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::read;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::copy;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::copy;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::metadata;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::metadata;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::remove_file;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::remove_file;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::create_dir_all;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::create_dir_all;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::remove_dir_all;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::remove_dir_all;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::DirBuilder;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::DirBuilder;
+
+#[cfg(feature = "async-std")]
+pub use async_std::fs::OpenOptions;
+#[cfg(feature = "tokio")]
+pub use tokio::fs::OpenOptions;
+
+#[cfg(feature = "async-std")]
+pub use async_std::io::BufReader;
+#[cfg(feature = "tokio")]
+pub use tokio::io::BufReader;
+
+#[cfg(feature = "async-std")]
+#[inline]
+pub fn lines_to_stream<R>(lines: futures::io::Lines<R>) -> futures::io::Lines<R> {
+    lines
+}
+#[cfg(feature = "tokio")]
+#[inline]
+pub fn lines_to_stream<R>(lines: tokio::io::Lines<R>) -> tokio_stream::wrappers::LinesStream<R> {
+    tokio_stream::wrappers::LinesStream::new(lines)
+}
+
+#[cfg(feature = "async-std")]
+pub use async_std::task::spawn_blocking;
+#[cfg(feature = "tokio")]
+pub use tokio::task::spawn_blocking;
+
+#[cfg(all(test, feature = "async-std"))]
+pub use async_std::task::block_on;
+#[cfg(all(test, feature = "tokio"))]
+#[inline]
+pub fn block_on<F, T>(future: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
+}
+
+#[cfg(feature = "async-std")]
+pub use async_std::task::JoinHandle;
+#[cfg(feature = "async-std")]
+#[inline]
+pub async fn unwrap_joinhandle<R>(handle: async_std::task::JoinHandle<R>) -> R {
+    handle.await
+}
+#[cfg(feature = "async-std")]
+#[inline]
+pub fn unwrap_joinhandle_value<T>(value: T) -> T {
+    value
+}
+#[cfg(feature = "tokio")]
+pub use tokio::task::JoinHandle;
+#[cfg(feature = "tokio")]
+#[inline]
+pub async fn unwrap_joinhandle<R>(handle: tokio::task::JoinHandle<R>) -> R {
+    handle.await.unwrap()
+}
+#[cfg(feature = "tokio")]
+#[inline]
+pub fn unwrap_joinhandle_value<T>(value: Result<T, tokio::task::JoinError>) -> T {
+    value.unwrap()
+}

--- a/src/content/rm.rs
+++ b/src/content/rm.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::Path;
 
-use async_std::fs as afs;
 use ssri::Integrity;
 
 use crate::content::path;
@@ -13,7 +12,7 @@ pub fn rm(cache: &Path, sri: &Integrity) -> Result<()> {
 }
 
 pub async fn rm_async(cache: &Path, sri: &Integrity) -> Result<()> {
-    afs::remove_file(path::content_path(cache, sri))
+    crate::async_lib::remove_file(path::content_path(cache, sri))
         .await
         .to_internal()?;
     Ok(())

--- a/src/content/write.rs
+++ b/src/content/write.rs
@@ -5,12 +5,12 @@ use std::pin::Pin;
 use std::sync::Mutex;
 use std::task::{Context, Poll};
 
-use crate::async_lib::{AsyncWrite, JoinHandle};
 use futures::prelude::*;
 use memmap2::MmapMut;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
 use tempfile::NamedTempFile;
 
+use crate::async_lib::{AsyncWrite, JoinHandle};
 use crate::content::path;
 use crate::errors::{Internal, Result};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,16 @@
 //! ```
 #![warn(missing_docs, missing_doc_code_examples)]
 
+#[cfg(not(any(feature = "async-std", feature = "tokio-runtime")))]
+compile_error!("Either feature \"async-std\" or \"tokio-runtime\" must be enabled for this crate.");
+
+#[cfg(all(feature = "async-std", feature = "tokio-runtime"))]
+compile_error!("Only either feature \"async-std\" or \"tokio-runtime\" must be enabled for this crate, not both.");
+
 pub use serde_json::Value;
 pub use ssri::Algorithm;
+
+mod async_lib;
 
 mod content;
 mod errors;

--- a/src/put.rs
+++ b/src/put.rs
@@ -468,7 +468,7 @@ mod tests {
         assert_eq!(result, original, "we did not read back what we wrote");
     }
 
-    #[async_attributes::test]
+    #[async_test]
     async fn hash_write_async() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().to_owned();

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -2,8 +2,6 @@
 use std::fs;
 use std::path::Path;
 
-use async_std::fs as afs;
-
 use ssri::Integrity;
 
 use crate::content::rm;
@@ -93,7 +91,9 @@ pub async fn remove_hash<P: AsRef<Path>>(cache: P, sri: &Integrity) -> Result<()
 /// ```
 pub async fn clear<P: AsRef<Path>>(cache: P) -> Result<()> {
     for entry in (cache.as_ref().read_dir().to_internal()?).flatten() {
-        afs::remove_dir_all(entry.path()).await.to_internal()?;
+        crate::async_lib::remove_dir_all(entry.path())
+            .await
+            .to_internal()?;
     }
     Ok(())
 }
@@ -182,11 +182,9 @@ pub fn clear_sync<P: AsRef<Path>>(cache: P) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use async_std::task;
-
     #[test]
     fn test_remove() {
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();
@@ -203,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_remove_data() {
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();
@@ -220,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        task::block_on(async {
+        crate::async_lib::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -182,9 +182,15 @@ pub fn clear_sync<P: AsRef<Path>>(cache: P) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn test_remove() {
-        crate::async_lib::block_on(async {
+
+    #[cfg(feature = "async-std")]
+    use async_attributes::test as async_test;
+    #[cfg(feature = "tokio")]
+    use tokio::test as async_test;
+
+    #[async_test]
+    async fn test_remove() {
+        futures::executor::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();
@@ -199,9 +205,9 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_remove_data() {
-        crate::async_lib::block_on(async {
+    #[async_test]
+    async fn test_remove_data() {
+        futures::executor::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();
@@ -216,9 +222,9 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_clear() {
-        crate::async_lib::block_on(async {
+    #[async_test]
+    async fn test_clear() {
+        futures::executor::block_on(async {
             let tmp = tempfile::tempdir().unwrap();
             let dir = tmp.path().to_owned();
             let sri = crate::write(&dir, "key", b"my-data").await.unwrap();


### PR DESCRIPTION
This PR is based on the work @alexschrod did in PR #29. All I did was carry it over the finish line.

This PR adds a feature to the crate named `tokio-runtime`. If you disable default features and enable this new one, cacache uses tokio as its async executor. This makes integrating cacache with tokio-using projects easier, because the file types leak out if you use anything more than the top-level convenience functions.

The PR implements the feature using shims in a new submodule named `async_lib`. This module conditionally uses either async-std or tokio based on feature selection, and hides some differences with convenience functions.

This change should not be a breaking change, because the default is still `async-std`.

There are a few other small changes in this PR worth noting.

- The README shows how to switch runtimes.
- There's a justfile to run common tasks, including those in makefile.toml. The default shell is `sh`, so this might not work out of the box for Windows users.
- The tests can now run under either runtime. The justfile has a recipe that runs them both.
- The benchmarks can also run under either runtime. The justfile has two recipe for this, one using bench and the other using criterion's runner.
- The dependencies now pull in async-attributes by default along with async-std. This made it easier to swap runtimes in the tests.
- All dependency versions have been bumped.

Co-authored-by: @alexschrod