### PR TITLE
fix(security): bump tempfile version to 3.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.68"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 ssri = "8.0.0"
-tempfile = "3.2.0"
+tempfile = "3.4.0"
 thiserror = "1.0.29"
 tokio = { version = "1.12.0", features = [
     "fs",


### PR DESCRIPTION
Hi Kat,
Just saw a dependabot note for a vulnerability in `remove_dir_all` which comes in via `tempfile` and has been fixed in 3.4.0 (see [their release notes](https://github.com/Stebalien/tempfile/blob/master/NEWS)) -- bumping version.