### PR TITLE
feat(mmap): new feature for mmap-based optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ digest = "0.10.6"
 either = "1.6.1"
 futures = "0.3.17"
 hex = "0.4.3"
-memmap2 = "0.5.8"
+memmap2 = { version = "0.5.8", optional = true }
 miette = "5.7.0"
 reflink = "0.1.3"
 serde = "1.0.130"
@@ -53,6 +53,7 @@ name = "benchmarks"
 harness = false
 
 [features]
-default = ["async-std"]
+default = ["async-std", "mmap"]
+mmap = ["memmap2"]
 link_to = []
 tokio-runtime = ["tokio", "tokio-stream"]


### PR DESCRIPTION
This is a workaround for #48 that makes the mmap optimization a feature that can be disabled.
I think it could be useful to let the user disable it, even if #48 is fixed; with the feature disabled it reduces the number of `unsafe` blocks in the code by a factor of 3:)