### PR TITLE
moved to reflink-copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.17"
 hex = "0.4.3"
 memmap2 = { version = "0.5.8", optional = true }
 miette = "5.7.0"
-reflink = "0.1.3"
+reflink-copy = "0.1.5"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"

--- a/src/content/read.rs
+++ b/src/content/read.rs
@@ -9,6 +9,7 @@ use futures::io::AsyncReadExt;
 #[cfg(feature = "tokio")]
 use tokio::io::AsyncReadExt;
 
+use reflink_copy as reflink;
 use ssri::{Algorithm, Integrity, IntegrityChecker};
 
 use crate::async_lib::AsyncRead;

--- a/src/index.rs
+++ b/src/index.rs
@@ -325,7 +325,7 @@ fn bucket_entries(bucket: &Path) -> std::io::Result<Vec<SerializableMetadata>> {
         .map(|file| {
             BufReader::new(file)
                 .lines()
-                .filter_map(std::result::Result::ok)
+                .map_while(std::result::Result::ok)
                 .filter_map(|entry| {
                     let entry_str = match entry.split('\t').collect::<Vec<&str>>()[..] {
                         [hash, entry_str] if hash_entry(entry_str) == hash => entry_str,


### PR DESCRIPTION
this replaces [reflink](https://github.com/nicokoch/reflink) with [reflink-copy](https://github.com/cargo-bins/reflink-copy) an updated fork

also adds a clippy fix for lines-filter-map-ok