### PR TITLE
feat(reflink): Separate reflink behavior into their own functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = { version = "0.3.17", optional = true }
 hex = "0.4.3"
 memmap2 = { version = "0.5.8", optional = true }
 miette = "5.7.0"
-reflink-copy = "0.1.5"
+reflink-copy = "0.1.9"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -317,7 +317,7 @@ fn write_hash_async_xxh3(c: &mut Criterion) {
 fn create_tmpfile(tmp: &tempfile::TempDir, buf: &[u8]) -> PathBuf {
     let dir = tmp.path().to_owned();
     let target = dir.join("target-file");
-    std::fs::create_dir_all(target.parent().unwrap().clone()).unwrap();
+    std::fs::create_dir_all(&target.parent().unwrap()).unwrap();
     let mut file = File::create(target.clone()).unwrap();
     file.write_all(buf).unwrap();
     file.flush().unwrap();

--- a/src/content/linkto.rs
+++ b/src/content/linkto.rs
@@ -44,7 +44,7 @@ fn create_symlink(sri: Integrity, cache: &PathBuf, target: &PathBuf) -> Result<I
                 cpath.parent().unwrap().display()
             )
         })?;
-    if let Err(e) = symlink_file(target, cpath.clone()) {
+    if let Err(e) = symlink_file(target, &cpath) {
         // If symlinking fails because there's *already* a file at the desired
         // destination, that is ok -- all the cache should care about is that
         // there is **some** valid file associated with the computed integrity.
@@ -187,8 +187,8 @@ mod tests {
     fn create_tmpfile(tmp: &tempfile::TempDir, buf: &[u8]) -> PathBuf {
         let dir = tmp.path().to_owned();
         let target = dir.join("target-file");
-        std::fs::create_dir_all(target.parent().unwrap().clone()).unwrap();
-        let mut file = File::create(target.clone()).unwrap();
+        std::fs::create_dir_all(&target.parent().unwrap()).unwrap();
+        let mut file = File::create(&target).unwrap();
         file.write_all(buf).unwrap();
         file.flush().unwrap();
         target
@@ -216,7 +216,7 @@ mod tests {
 
         let cpath = path::content_path(&dir, &sri);
         assert!(cpath.exists());
-        let metadata = std::fs::symlink_metadata(cpath.clone()).unwrap();
+        let metadata = std::fs::symlink_metadata(&cpath).unwrap();
         let file_type = metadata.file_type();
         assert!(file_type.is_symlink());
         assert_eq!(std::fs::read(cpath).unwrap(), b"hello world");
@@ -249,7 +249,7 @@ mod tests {
 
         let cpath = path::content_path(&dir, &sri);
         assert!(cpath.exists());
-        let metadata = std::fs::symlink_metadata(cpath.clone()).unwrap();
+        let metadata = std::fs::symlink_metadata(&cpath).unwrap();
         let file_type = metadata.file_type();
         assert!(file_type.is_symlink());
         assert_eq!(std::fs::read(cpath).unwrap(), b"hello world");

--- a/src/linkto.rs
+++ b/src/linkto.rs
@@ -502,8 +502,8 @@ mod tests {
     fn create_tmpfile(tmp: &tempfile::TempDir, buf: &[u8]) -> PathBuf {
         let dir = tmp.path().to_owned();
         let target = dir.join("target-file");
-        std::fs::create_dir_all(target.parent().unwrap().clone()).unwrap();
-        let mut file = File::create(target.clone()).unwrap();
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        let mut file = File::create(&target).unwrap();
         file.write_all(buf).unwrap();
         file.flush().unwrap();
         target


### PR DESCRIPTION
BREAKING CHANGE: some signatures for copy have changed, and copy no longer automatically reflinks