### PR TITLE
use const_hex to replace hex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ async-std = { version = "1.10.0", features = ["unstable"], optional = true }
 digest = "0.10.6"
 either = "1.6.1"
 futures = { version = "0.3.17", optional = true }
-hex = "0.4.3"
+const-hex = "1.0.0"
 memmap2 = { version = "0.5.8", optional = true }
 miette = "5.7.0"
 reflink-copy = "0.1.9"

--- a/src/index.rs
+++ b/src/index.rs
@@ -309,13 +309,13 @@ fn bucket_path(cache: &Path, key: &str) -> PathBuf {
 fn hash_key(key: &str) -> String {
     let mut hasher = Sha1::new();
     hasher.update(key);
-    hex::encode(hasher.finalize())
+    const_hex::encode(hasher.finalize())
 }
 
 fn hash_entry(key: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(key);
-    hex::encode(hasher.finalize())
+    const_hex::encode(hasher.finalize())
 }
 
 fn now() -> u128 {


### PR DESCRIPTION
`hex` does not got an update for 3 years, `const-hex` aims to be a drop-in replacement for the [hex](https://crates.io/crates/hex) crate.

So, why not replace it?